### PR TITLE
Implement reset camera parameters

### DIFF
--- a/src/CameraComponent.cpp
+++ b/src/CameraComponent.cpp
@@ -302,6 +302,14 @@ int CameraComponent::setCameraMode(uint32_t mode)
     return 0;
 }
 
+int CameraComponent::resetCameraSettings()
+{
+    int ret = mCamDev->resetParams(mCamParam);
+    if (ret != 0)
+        log_debug("Error in reset of camera parameters. Could not open the device.");
+    return ret;
+}
+
 int CameraComponent::getCameraMode()
 {
     return mCamDev->getMode();

--- a/src/CameraComponent.h
+++ b/src/CameraComponent.h
@@ -77,6 +77,7 @@ public:
     virtual int stopImageCapture();
     void cbImageCaptured(int result, int seq_num);
     virtual int setImageLocation(std::string imgPath);
+    int resetCameraSettings(void);
 
 private:
     std::string mCamDevName;               /* Camera device name */

--- a/src/CameraDevice.h
+++ b/src/CameraDevice.h
@@ -51,7 +51,7 @@ public:
     virtual int start(std::function<void(std::vector<uint8_t>)> cb) { return -ENOTSUP; }
     virtual int stop() { return -ENOTSUP; }
     virtual std::vector<uint8_t> read() { return {}; }
-    virtual int resetParams() { return -ENOTSUP; }
+    virtual int resetParams(CameraParameters &camParam) { return -ENOTSUP; }
     virtual int setParam(const char *param_id, size_t id_size, const char *param_value,
                          size_t value_size, int param_type) { return -ENOTSUP; }
     virtual int setParam(std::string param_id, float param_value) { return -ENOTSUP; }

--- a/src/CameraDeviceV4l2.h
+++ b/src/CameraDeviceV4l2.h
@@ -51,6 +51,7 @@ public:
     int setExposureAbsolute(uint32_t value);
     int setSceneMode(uint32_t value);
     int setHue(int32_t value);
+    int resetParams(CameraParameters &camParam);
 
 private:
     std::string mDeviceId;

--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -518,6 +518,26 @@ void MavlinkServer::_handle_param_ext_set(const struct sockaddr_in &addr, mavlin
     }
 }
 
+void MavlinkServer::_handle_reset_camera_settings(const struct sockaddr_in &addr,
+                                                  mavlink_command_long_t &cmd)
+{
+
+    if (cmd.param1 != 1) {
+        _send_ack(addr, cmd.command, cmd.target_component, true);
+        return;
+    }
+
+    bool success = false;
+    CameraComponent *tgtComp = getCameraComponent(cmd.target_component);
+
+    if (tgtComp) {
+        if (!tgtComp->resetCameraSettings())
+            success = true;
+    }
+
+    _send_ack(addr, cmd.command, cmd.target_component, success);
+}
+
 void MavlinkServer::_handle_mavlink_message(const struct sockaddr_in &addr, mavlink_message_t *msg)
 {
     // log_debug("Message received: (sysid: %d compid: %d msgid: %d)", msg->sysid, msg->compid,
@@ -551,7 +571,7 @@ void MavlinkServer::_handle_mavlink_message(const struct sockaddr_in &addr, mavl
             this->_handle_request_camera_capture_status(addr, cmd);
             break;
         case MAV_CMD_RESET_CAMERA_SETTINGS:
-            log_debug("MAV_CMD_RESET_CAMERA_SETTINGS");
+            this->_handle_reset_camera_settings(addr, cmd);
             break;
         case MAV_CMD_REQUEST_STORAGE_INFORMATION:
             this->_handle_request_storage_information(addr, cmd);

--- a/src/mavlink_server.h
+++ b/src/mavlink_server.h
@@ -77,6 +77,7 @@ private:
     void _handle_param_ext_request_read(const struct sockaddr_in &addr, mavlink_message_t *msg);
     void _handle_param_ext_request_list(const struct sockaddr_in &addr, mavlink_message_t *msg);
     void _handle_param_ext_set(const struct sockaddr_in &addr, mavlink_message_t *msg);
+    void _handle_reset_camera_settings(const struct sockaddr_in &addr, mavlink_command_long_t &cmd);
     bool _send_mavlink_message(const struct sockaddr_in *addr, mavlink_message_t &msg);
     void _send_ack(const struct sockaddr_in &addr, int cmd, int comp_id, bool success);
     const Stream::FrameSize *_find_best_frame_size(Stream &s, uint32_t w, uint32_t v);


### PR DESCRIPTION
Upon receiving MAV_CMD_RESET_CAMERA_SETTINGS, csd should reset those camera parameters which can be set.